### PR TITLE
Changed to using references and fixed CSR -> Dense conversion.

### DIFF
--- a/SDDMMlib/include/MatrixLib/CSRMatrix.hpp
+++ b/SDDMMlib/include/MatrixLib/CSRMatrix.hpp
@@ -43,9 +43,9 @@ class CSRMatrix : virtual public SparseMatrix<T>
         virtual int getNumCols() const override;
         virtual T at(int row, int col) const override;
         virtual int getNumValues() const override;
-        virtual std::vector<T> getValues() const override;
-        virtual std::vector<int> getColIndices() const override;
-        virtual std::vector<int> getRowPtr() const override;
+        virtual const std::vector<T>& getValues() const override;
+        virtual const std::vector<int>& getColIndices() const override;
+        virtual const std::vector<int>& getRowPtr() const override;
 
         virtual void setValues(const std::vector<T>& values) override;
         virtual void setColIndices(const std::vector<int>& colIndices) override;

--- a/SDDMMlib/include/MatrixLib/DenseMatrix.hpp
+++ b/SDDMMlib/include/MatrixLib/DenseMatrix.hpp
@@ -21,7 +21,7 @@ class DenseMatrix
 
         int getNumRows() const;
         int getNumCols() const;
-        std::vector<std::vector<T>> getValues();  // added this, don't see why we should not have it
+        const std::vector<std::vector<T>>& getValues();  // added this, don't see why we should not have it
         T at(int row, int col) const;
         void setValue(int row, int col, T value);
         void transpose();

--- a/SDDMMlib/include/MatrixLib/SparseMatrix.hpp
+++ b/SDDMMlib/include/MatrixLib/SparseMatrix.hpp
@@ -29,9 +29,9 @@ class SparseMatrix
         virtual int getNumCols() const = 0;
         virtual T at(int row, int col) const = 0;
         virtual int getNumValues() const = 0;
-        virtual std::vector<T> getValues() const = 0;
-        virtual std::vector<int> getColIndices() const = 0;
-        virtual std::vector<int> getRowPtr() const = 0;
+        virtual const std::vector<T>& getValues() const = 0;
+        virtual const std::vector<int>& getColIndices() const = 0;
+        virtual const std::vector<int>& getRowPtr() const = 0;
 
         virtual void setValues(const std::vector<T>& values) = 0;
         virtual void setColIndices(const std::vector<int>& colIndices) = 0;

--- a/SDDMMlib/src/MatrixLib/CSRMatrix.cpp
+++ b/SDDMMlib/src/MatrixLib/CSRMatrix.cpp
@@ -222,7 +222,7 @@ T CSRMatrix<T>::at(int row, int col) const
 }
 
 template <typename T>
-std::vector<T> CSRMatrix<T>::getValues() const
+const std::vector<T>& CSRMatrix<T>::getValues() const
 {
     return values;
 }
@@ -234,13 +234,13 @@ int CSRMatrix<T>::getNumValues() const
 }
 
 template <typename T>
-std::vector<int> CSRMatrix<T>::getColIndices() const
+const std::vector<int>& CSRMatrix<T>::getColIndices() const
 {
     return colIndices;
 }
 
 template <typename T>
-std::vector<int> CSRMatrix<T>::getRowPtr() const
+const std::vector<int>& CSRMatrix<T>::getRowPtr() const
 {
     return rowPtr;
 }

--- a/SDDMMlib/src/MatrixLib/DenseMatrix.cpp
+++ b/SDDMMlib/src/MatrixLib/DenseMatrix.cpp
@@ -30,9 +30,9 @@ DenseMatrix<T>::DenseMatrix(CSRMatrix<T>& csrMatrix)
     std::vector<std::vector<T>> vals(this->numRows, std::vector<T>(this->numCols, 0));
 
     // main loop
-    std::vector<int> rowIndices = csrMatrix.getRowPtr();
-    std::vector<int> columnIndices = csrMatrix.getColIndices();
-    std::vector<T> values = csrMatrix.getValues();
+    const std::vector<int>& rowIndices = csrMatrix.getRowPtr();
+    const std::vector<int>& columnIndices = csrMatrix.getColIndices();
+    const std::vector<T>& values = csrMatrix.getValues();
     for (int rowIndicesArrayRunner = 0; rowIndicesArrayRunner < rowIndices.size(); rowIndicesArrayRunner++)
     {
         int num_elems_in_row = rowIndices[rowIndicesArrayRunner + 1] - rowIndices[rowIndicesArrayRunner];
@@ -43,7 +43,6 @@ DenseMatrix<T>::DenseMatrix(CSRMatrix<T>& csrMatrix)
             int value = values[index];
             vals[rowIndicesArrayRunner][column_index] = value;
         }
-        rowIndicesArrayRunner++;
     }
 
     this->values = vals;
@@ -63,7 +62,7 @@ int DenseMatrix<T>::getNumCols() const
 
 // added this, don't see why we should not have it
 template <typename T>
-std::vector<std::vector<T>> DenseMatrix<T>::getValues()
+const std::vector<std::vector<T>>& DenseMatrix<T>::getValues()
 {
     return this->values;
 }

--- a/SDDMMlib/tests/MatrixLib/test_IO_Dense.cpp
+++ b/SDDMMlib/tests/MatrixLib/test_IO_Dense.cpp
@@ -66,9 +66,9 @@ void mainTest()
 void testCsrToDense()
 {
     std::vector<std::vector<int>> in = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
-    CSRMatrix<int> matrixCSR(std::vector<std::vector<int>>{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}});
+    CSRMatrix<int> matrixCSR = CSRMatrix<int>(DenseMatrix<int>(in));
     DenseMatrix<int> matrixDense(matrixCSR);
-    std::vector<std::vector<int>> vals = matrixDense.getValues();
+    const std::vector<std::vector<int>>& vals = matrixDense.getValues();
     // compare both value vectors
     assert(vals == in && "Incorrect CSR to Dense conversion");
 }


### PR DESCRIPTION
Solving Issues: [Reduce copying of variables where possible](https://github.com/ericschreiber/DPHPC23-SmokyRhino/issues/8), [Getter&Setter returning references](https://github.com/ericschreiber/DPHPC23-SmokyRhino/issues/9)

And fixing CSR -> Dense Constructor as it was skipping each second row index.